### PR TITLE
chore: board-contracts bump to v1.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@tanstack/react-query": "^4.29.3",
         "antd": "^5.10.0",
         "axios": "^1.3.6",
-        "board-contracts": "^1.0.21",
+        "board-contracts": "^1.0.25",
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "echarts-for-react": "^3.0.2",
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/board-contracts": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/board-contracts/-/board-contracts-1.0.21.tgz",
-      "integrity": "sha512-6ggOBGjXRTC2K5LXAf64l60O9esH7XlB9UMiz/JMZjLLIIoSlOFdtLAyl5dzv1JRhswaa/mxZkv9bUQvuIngVw==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/board-contracts/-/board-contracts-1.0.25.tgz",
+      "integrity": "sha512-goy/DRNf8+wn7E7b9R33prx4+AwUJRiG+OlIqUqm3qFESKcJVodDsyb2BsBmod8WoPD22sg/T+zMEwxbSh6Q5A==",
       "dependencies": {
         "myzod": "^1.10.2"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@tanstack/react-query": "^4.29.3",
     "antd": "^5.10.0",
     "axios": "^1.3.6",
-    "board-contracts": "^1.0.21",
+    "board-contracts": "^1.0.25",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "echarts-for-react": "^3.0.2",

--- a/src/components/DragAndDrop/DragAndDrop.tsx
+++ b/src/components/DragAndDrop/DragAndDrop.tsx
@@ -56,10 +56,9 @@ export const DragAndDrop = ({
   };
 
   const handleOnDragEnd = (result: DropResult) => {
-    const { list, mappedResult } = reorder(dataSource.columns, result);
+    const { mappedResult } = reorder(dataSource.columns, result);
 
     onDragEnd(mappedResult);
-    // setData(isError ? list : mappedResult);
   };
 
   return (


### PR DESCRIPTION
## What
Bump `board-contracts` to version `1.0.25`